### PR TITLE
Refactor daily runner for scheduled maintenance

### DIFF
--- a/DailyRunner.gs
+++ b/DailyRunner.gs
@@ -1,84 +1,15 @@
 /**
- * ActivateAndTest_Menu.gs
+ * DailyRunner.gs
+ * Funções chamadas por triggers agendados para manutenção diária.
  */
 
-function oneClickActivate_() {
-  try { ensureSpreadsheetTZ_(); } catch(e){ Logger.log(e); }
-  try { ensureRef_(); } catch(e){ Logger.log(e); }
-  try { ensureDashboard(); } catch(e){ Logger.log(e); }
-  try { ensureSummary(); } catch(e){ Logger.log(e); }
-  try { ensureHistory30(); } catch(e){ Logger.log(e); }
-  try { ensureReliability30Sheet_(); } catch(e){ Logger.log(e); }
-  try { ensureAlerts(); } catch(e){ Logger.log(e); }
-  try { ensureAlertStateSheets_(); } catch(e){ Logger.log(e); }
-  try { ensureHeartbeat_(); } catch(e){ Logger.log(e); }
-  try { ensureWeeklyScaffold_(); } catch(e){ Logger.log(e); }
-
-  try { setupMonitoringTriggers_(); } catch(e){ Logger.log(e); }
-  try { setupMaintenanceTriggers_(); } catch(e){ Logger.log(e); }
-
-  try { pushDiscordActivationPing_(); } catch(e){ Logger.log(e); }
-  try { testEmail_(); } catch(e){ Logger.log(e); }
-
-  return 'OK: Triggers definidos, folhas asseguradas e notificações testadas.';
+/** Executa a rotina de atualização diária dos artefatos. */
+function runDailyRefresh_() {
+  try { refreshDailyArtifacts_(); } catch (e) { Logger.log(e); }
 }
 
-function pushDiscordActivationPing_() {
-  if (!DISCORD_WEBHOOK_URL) return 'Sem webhook configurado';
-  const embed = {
-    title: '🚀 Cripto Dashboard — Ativação concluída',
-    description: 'Triggers ativos (monitor & manutenção). Painel/Resumo/Alertas prontos.',
-    url: SHEET_URL,
-    color: 0x3498DB,
-    fields: [
-      { name: 'Monitor', value: 'cada 15 minutos', inline: true },
-      { name: 'Manutenção diária', value: '23:55', inline: true }
-    ],
-    footer: { text: 'Fonte: Google Sheets' },
-    timestamp: new Date().toISOString()
-  };
-  const payload = { embeds: [embed], content: '' };
-  discordPost_(payload);
-  return 'Ping enviado para Discord.';
-}
-function testEmail_() {
-  if (!ALERT_EMAILS || !ALERT_EMAILS.length) return 'Sem destinatários.';
-  const subject = 'Cripto Dashboard — Teste de ativação';
-  const htmlBody = '<h3>✅ Ativação concluída</h3><p>Triggers criados e folhas atualizadas.</p>' +
-                   '<p><a href="'+SHEET_URL+'">Abrir Dashboard</a></p>';
-  ALERT_EMAILS.forEach(to => MailApp.sendEmail({ to, subject, htmlBody, noReply: true }));
-  return 'E-mail de teste enviado.';
-}
-function testAllNotifications_() {
-  const a = pushDiscordActivationPing_();
-  const b = testEmail_();
-  return a + ' | ' + b;
+/** Verifica se as execuções do dia ocorreram como esperado. */
+function runDailyMonitor_() {
+  try { checkDailyRuns_(); } catch (e) { Logger.log(e); }
 }
 
-// Teste de POST ao Web App com payload fictício
-function testWebAppPost_() {
-  const url = 'https://script.google.com/macros/s/AKfycbzkN0tlMxF4_Rk2itshs6naa_aPIUyd4Y_9Tv5q3N65VGQoAKdYI0RLfYBO24XV3Vl3HA/exec';
-  const now = new Date();
-  const iso = Utilities.formatDate(now, TZ, "yyyy-MM-dd'T'HH:mm:ssXXX");
-  const payload = {
-    secret: SECRET,
-    report: { reportId: 'TEST-'+now.getTime(), runAtISO: iso, windowLabel: '18:00' },
-    items: ASSETS.map((sym, i) => ({
-      symbol: sym, price: 100+i, open: 99+i, high: 101+i, low: 98+i, close: 100+i,
-      var24h: 0.5, var7d: 1.2, var30d: 5.3,
-      rsi14: 55, macdLine: 0.2, macdSignal: 0.1, macdHist: 0.1,
-      sma20: 100, sma50: 100, sma100: 100, sma200: 100,
-      bollMiddle: 100, bollUpper: 102, bollLower: 98, bollWidth: 0.04,
-      atr14: 1.2, sarValue: 99.5, sarSide: 'long', volume: 123456, volDivergence: 0,
-      trend: 'lateral', recommendation: '🔁 Manter', justification: 'Teste',
-      headline: 'Sem notícias', newsUrl: '', fearGreed: 50, contextNotes: 'Demo'
-    })),
-    // opcional: conteúdo de texto/markdown da tua task
-    markdown: "## Exemplo de relatório MD\n\n- BTC: ...\n- ETH: ...\n"
-  };
-  const res = UrlFetchApp.fetch(url, {
-    method: 'post', contentType: 'application/json', payload: JSON.stringify(payload), muteHttpExceptions: true
-  });
-  Logger.log(res.getResponseCode() + ' ' + res.getContentText());
-  return res.getContentText();
-}


### PR DESCRIPTION
## Summary
- Simplify DailyRunner script to only handle daily maintenance tasks
- Add wrappers to refresh daily artifacts and monitor daily runs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fcbf77788326babd27cfa217bcda