### PR TITLE
Retrieve test Web App URL from script properties

### DIFF
--- a/ActivateAndTest_Menu.gs
+++ b/ActivateAndTest_Menu.gs
@@ -57,7 +57,13 @@ function testAllNotifications_() {
 
 // Teste de POST ao Web App com payload fictício
 function testWebAppPost_() {
-  const url = 'https://script.google.com/macros/s/AKfycbzkN0tlMxF4_Rk2itshs6naa_aPIUyd4Y_9Tv5q3N65VGQoAKdYI0RLfYBO24XV3Vl3HA/exec';
+  const prop = PropertiesService.getScriptProperties();
+  let url = prop.getProperty('WEB_APP_URL');
+  if (!url) {
+    url = Browser.inputBox('Informe a URL do Web App para testes:');
+    if (!url || url === 'cancel') return 'URL do Web App não fornecida.';
+    prop.setProperty('WEB_APP_URL', url);
+  }
   const now = new Date();
   const iso = Utilities.formatDate(now, TZ, "yyyy-MM-dd'T'HH:mm:ssXXX");
   const payload = {

--- a/DailyRunner.gs
+++ b/DailyRunner.gs
@@ -13,3 +13,37 @@ function runDailyMonitor_() {
   try { checkDailyRuns_(); } catch (e) { Logger.log(e); }
 }
 
+// Teste de POST ao Web App com payload fictício
+function testWebAppPost_() {
+  const prop = PropertiesService.getScriptProperties();
+  let url = prop.getProperty('WEB_APP_URL');
+  if (!url) {
+    url = Browser.inputBox('Informe a URL do Web App para testes:');
+    if (!url || url === 'cancel') return 'URL do Web App não fornecida.';
+    prop.setProperty('WEB_APP_URL', url);
+  }
+  const now = new Date();
+  const iso = Utilities.formatDate(now, TZ, "yyyy-MM-dd'T'HH:mm:ssXXX");
+  const payload = {
+    secret: SECRET,
+    report: { reportId: 'TEST-'+now.getTime(), runAtISO: iso, windowLabel: '18:00' },
+    items: ASSETS.map((sym, i) => ({
+      symbol: sym, price: 100+i, open: 99+i, high: 101+i, low: 98+i, close: 100+i,
+      var24h: 0.5, var7d: 1.2, var30d: 5.3,
+      rsi14: 55, macdLine: 0.2, macdSignal: 0.1, macdHist: 0.1,
+      sma20: 100, sma50: 100, sma100: 100, sma200: 100,
+      bollMiddle: 100, bollUpper: 102, bollLower: 98, bollWidth: 0.04,
+      atr14: 1.2, sarValue: 99.5, sarSide: 'long', volume: 123456, volDivergence: 0,
+      trend: 'lateral', recommendation: '🔁 Manter', justification: 'Teste',
+      headline: 'Sem notícias', newsUrl: '', fearGreed: 50, contextNotes: 'Demo'
+    })),
+    // opcional: conteúdo de texto/markdown da tua task
+    markdown: "## Exemplo de relatório MD\n\n- BTC: ...\n- ETH: ...\n"
+  };
+  const res = UrlFetchApp.fetch(url, {
+    method: 'post', contentType: 'application/json', payload: JSON.stringify(payload), muteHttpExceptions: true
+  });
+  Logger.log(res.getResponseCode() + ' ' + res.getContentText());
+  return res.getContentText();
+}
+


### PR DESCRIPTION
## Summary
- Load Web App test URL from a script property in `testWebAppPost_`
- Prompt for URL and save when no property is set
- Mirror the dynamic URL logic in `DailyRunner` test helper

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b804ff027c8326908bb38727b3881d