### PR TITLE
Add neutral analysis handler for menu

### DIFF
--- a/DailyRunner.gs
+++ b/DailyRunner.gs
@@ -13,6 +13,17 @@ function runDailyMonitor_() {
   try { checkDailyRuns_(); } catch (e) { Logger.log(e); }
 }
 
+/**
+ * Executa imediatamente a análise neutra.
+ * Atualmente, delega para a rotina de atualização diária
+ * para garantir que os artefatos sejam atualizados.
+ */
+function runNeutralAnalysisNow_(label) {
+  Logger.log('runNeutralAnalysisNow_ ' + label);
+  runDailyRefresh_();
+  return { ok: true, label: label };
+}
+
 // Teste de POST ao Web App com payload fictício
 function testWebAppPost_() {
   const prop = PropertiesService.getScriptProperties();


### PR DESCRIPTION
## Summary
- add `runNeutralAnalysisNow_` wrapper so the DailyRunner menu action no longer errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba08f0d7108326b5b2ed86aefe6787