### PR TITLE
Use Script Properties for configuration

### DIFF
--- a/ActivateAndTest_Menu.gs
+++ b/ActivateAndTest_Menu.gs
@@ -24,7 +24,7 @@ function oneClickActivate_() {
 }
 
 function pushDiscordActivationPing_() {
-  if (!DISCORD_WEBHOOK_URL) return 'Sem webhook configurado';
+  if (!discordWebhookUrl_()) return 'Sem webhook configurado';
   const embed = {
     title: '🚀 Cripto Dashboard — Ativação concluída',
     description: 'Triggers ativos (monitor & manutenção). Painel/Resumo/Alertas prontos.',
@@ -42,11 +42,12 @@ function pushDiscordActivationPing_() {
   return 'Ping enviado para Discord.';
 }
 function testEmail_() {
-  if (!ALERT_EMAILS || !ALERT_EMAILS.length) return 'Sem destinatários.';
+  const emails = getAlertEmails_();
+  if (!emails.length) return 'Sem destinatários.';
   const subject = 'Cripto Dashboard — Teste de ativação';
   const htmlBody = '<h3>✅ Ativação concluída</h3><p>Triggers criados e folhas atualizadas.</p>' +
                    '<p><a href="'+SHEET_URL+'">Abrir Dashboard</a></p>';
-  ALERT_EMAILS.forEach(to => MailApp.sendEmail({ to, subject, htmlBody, noReply: true }));
+  emails.forEach(to => MailApp.sendEmail({ to, subject, htmlBody, noReply: true }));
   return 'E-mail de teste enviado.';
 }
 function testAllNotifications_() {
@@ -67,7 +68,7 @@ function testWebAppPost_() {
   const now = new Date();
   const iso = Utilities.formatDate(now, TZ, "yyyy-MM-dd'T'HH:mm:ssXXX");
   const payload = {
-    secret: SECRET,
+    secret: getSecret_(),
     report: { reportId: 'TEST-'+now.getTime(), runAtISO: iso, windowLabel: '18:00' },
     items: ASSETS.map((sym, i) => ({
       symbol: sym, price: 100+i, open: 99+i, high: 101+i, low: 98+i, close: 100+i,

--- a/DailyRunner.gs
+++ b/DailyRunner.gs
@@ -36,7 +36,7 @@ function testWebAppPost_() {
   const now = new Date();
   const iso = Utilities.formatDate(now, TZ, "yyyy-MM-dd'T'HH:mm:ssXXX");
   const payload = {
-    secret: SECRET,
+    secret: getSecret_(),
     report: { reportId: 'TEST-'+now.getTime(), runAtISO: iso, windowLabel: '18:00' },
     items: ASSETS.map((sym, i) => ({
       symbol: sym, price: 100+i, open: 99+i, high: 101+i, low: 98+i, close: 100+i,

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # Read Me
+
+## Configuração
+
+Alguns valores sensíveis não são mais definidos no código fonte e devem ser
+armazenados nas *Script Properties* do projeto Apps Script.
+
+Propriedades esperadas:
+
+- `SECRET` – segredo compartilhado usado para autorizar chamadas ao webhook.
+- `DISCORD_WEBHOOK_URL` – URL do webhook do Discord para envio de notificações.
+- `ALERT_EMAILS` – lista de e-mails separados por vírgula que receberão alertas.
+
+As propriedades podem ser definidas manualmente em **Project Settings → Script
+properties**, ou programaticamente executando uma função como a abaixo uma vez:
+
+```javascript
+function initProps_() {
+  PropertiesService.getScriptProperties().setProperties({
+    SECRET: 'minha-senha',
+    DISCORD_WEBHOOK_URL: 'https://discord.com/api/webhooks/...',
+    ALERT_EMAILS: 'user@example.com,other@example.com'
+  });
+}
+```
+
+Execute `initProps_` no editor do Apps Script ou ajuste os valores pela
+interface antes de implantar o projeto.


### PR DESCRIPTION
## Summary
- remove hardcoded SECRET, DISCORD_WEBHOOK_URL and ALERT_EMAILS from the dashboard code
- load sensitive values from Script Properties and update all references
- document how to configure required Script Properties during deployment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3c710dbc8326b5e383aeee07f9a9