### PR TITLE
Restrict web app access

### DIFF
--- a/appsscript.json
+++ b/appsscript.json
@@ -5,6 +5,6 @@
     "runtimeVersion": "V8",
     "webapp": {
         "executeAs": "USER_DEPLOYING",
-        "access": "ANYONE_ANONYMOUS"
+        "access": "ANYONE"
     }
 }


### PR DESCRIPTION
## Summary
- limit web app access from anonymous to any user

## Testing
- `clasp deploy` *(fails: No credentials found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3067c74c8326beabff135d46b14b