### PR TITLE
Remove unused two-daily analysis menu option

### DIFF
--- a/CriptoDashboard_FULL.gs
+++ b/CriptoDashboard_FULL.gs
@@ -1216,7 +1216,6 @@ function buildMenu_(){
     .addItem('Testar Notificações (Discord/Email)', 'testAllNotifications_')
     .addSeparator()
     .addItem('Executar análise agora (DailyRunner)', 'runNeutralAnalysisNow_Menu_')
-    .addItem('Agendar 2×/dia (DailyRunner)', 'activateTwoDailyAnalyses_')
     .addSeparator()
     .addItem('Atualizar artefactos diários agora', 'refreshDailyArtifacts_')
     .addToUi();


### PR DESCRIPTION
## Summary
- Remove menu entry referencing undefined `activateTwoDailyAnalyses_` trigger

## Testing
- `node` menu handler simulation to ensure all menu items execute without runtime errors

------
https://chatgpt.com/codex/tasks/task_e_68bb320bc79c8326a68d2e132d43b58e