### PR TITLE
Fix formula repair applies alerts conditional formatting

### DIFF
--- a/CriptoDashboard_FULL.gs
+++ b/CriptoDashboard_FULL.gs
@@ -1282,7 +1282,7 @@ function runNeutralAnalysisNow_Menu_(){
 function fixFormulaErrorsNow_(){
   const ss = SS_();
   const p = ss.getSheetByName(DASHBOARD_SHEET); if (p) buildDashboardLayout_(p);
-  const a = ss.getSheetByName(ALERTS_SHEET);    if (a) buildAlertsLayout_(a);
+  const a = ss.getSheetByName(ALERTS_SHEET);    if (a) { buildAlertsLayout_(a); addAlertsFormatting_(a); }
   const s = ss.getSheetByName(SUMMARY_SHEET);   if (s) refreshSummaryCharts_(s);
   SpreadsheetApp.getActive().toast('Formulas reconstruídas. Verifique Painel/Alertas/Resumo.');
 }


### PR DESCRIPTION
## Summary
- Ensure `fixFormulaErrorsNow_` rebuilds alert sheet formatting

## Testing
- `node verify.js` (removed) -> rules count: 11
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68bb48eacec4832690ca91eafd30151f