### PR TITLE
Add locking to daily runner functions

### DIFF
--- a/DailyRunner.gs
+++ b/DailyRunner.gs
@@ -5,12 +5,34 @@
 
 /** Executa a rotina de atualização diária dos artefatos. */
 function runDailyRefresh_() {
-  try { refreshDailyArtifacts_(); } catch (e) { Logger.log(e); }
+  const lock = LockService.getScriptLock();
+  if (!lock.tryLock(30 * 1000)) {
+    Logger.log('runDailyRefresh_ lock unavailable');
+    return;
+  }
+  try {
+    refreshDailyArtifacts_();
+  } catch (e) {
+    Logger.log(e);
+  } finally {
+    lock.releaseLock();
+  }
 }
 
 /** Verifica se as execuções do dia ocorreram como esperado. */
 function runDailyMonitor_() {
-  try { checkDailyRuns_(); } catch (e) { Logger.log(e); }
+  const lock = LockService.getScriptLock();
+  if (!lock.tryLock(30 * 1000)) {
+    Logger.log('runDailyMonitor_ lock unavailable');
+    return;
+  }
+  try {
+    checkDailyRuns_();
+  } catch (e) {
+    Logger.log(e);
+  } finally {
+    lock.releaseLock();
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- protect daily refresh and monitor routines with a script lock to prevent concurrent execution

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb679a5c988326b6d18023694f21c4