### PR TITLE
Improve Discord posting robustness and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Propriedades esperadas:
 
 - `SECRET` – segredo compartilhado usado para autorizar chamadas ao webhook.
 - `DISCORD_WEBHOOK_URL` – URL do webhook do Discord para envio de notificações.
+- `DISCORD_ERROR_WEBHOOK_URL` – webhook opcional para alertas quando o envio falhar.
 - `ALERT_EMAILS` – lista de e-mails separados por vírgula que receberão alertas.
 
 As propriedades podem ser definidas manualmente em **Project Settings → Script
@@ -19,6 +20,7 @@ function initProps_() {
   PropertiesService.getScriptProperties().setProperties({
     SECRET: 'minha-senha',
     DISCORD_WEBHOOK_URL: 'https://discord.com/api/webhooks/...',
+    DISCORD_ERROR_WEBHOOK_URL: 'https://discord.com/api/webhooks/erro...',
     ALERT_EMAILS: 'user@example.com,other@example.com'
   });
 }


### PR DESCRIPTION
## Summary
- Enforce Discord payload limits: trim content to 2000 chars, cap embeds to 10 with conservative field sizes
- Retry once on HTTP 429 and surface non‑2xx responses as errors
- Support optional `DISCORD_ERROR_WEBHOOK_URL` for alerting when posts fail

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6b478a9c8326a4f7e663b345f386