### PR TITLE
feat: add AI market summary via OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Propriedades esperadas:
 - `DISCORD_WEBHOOK_URL` – URL do webhook do Discord para envio de notificações.
 - `DISCORD_ERROR_WEBHOOK_URL` – webhook opcional para alertas quando o envio falhar.
 - `ALERT_EMAILS` – lista de e-mails separados por vírgula que receberão alertas.
+- `OPENAI_API_KEY` – chave da API da OpenAI usada para gerar resumos automáticos.
 
 As propriedades podem ser definidas manualmente em **Project Settings → Script
 properties**, ou programaticamente executando uma função como a abaixo uma vez:
@@ -21,7 +22,8 @@ function initProps_() {
     SECRET: 'minha-senha',
     DISCORD_WEBHOOK_URL: 'https://discord.com/api/webhooks/...',
     DISCORD_ERROR_WEBHOOK_URL: 'https://discord.com/api/webhooks/erro...',
-    ALERT_EMAILS: 'user@example.com,other@example.com'
+    ALERT_EMAILS: 'user@example.com,other@example.com',
+    OPENAI_API_KEY: 'sk-...'
   });
 }
 ```


### PR DESCRIPTION
## Summary
- read OPENAI_API_KEY from Script Properties
- generate AI market summary using GPT-4o mini and post to Discord
- store generated summary in the `Resumo` sheet

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf793bacc8326a0fd26cde1c188fb